### PR TITLE
Add Arm support for aarch64 and armv7l

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,6 @@ jobs:
       - name: asdf_plugin_test
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v1
         with:
           command: 'dust --version'

--- a/bin/install
+++ b/bin/install
@@ -3,8 +3,9 @@
 set -e
 set -o pipefail
 
-# https://github.com/bootandy/dust/releases/download/v0.5.1/dust-v0.5.1-x86_64-unknown-linux-musl.tar.gz
-# https://github.com/bootandy/dust/releases/download/v0.5.1/dust-v0.5.1-x86_64-apple-darwin.tar.gz
+# https://github.com/bootandy/dust/releases/download/v0.7.5/dust-v0.7.5-arm-unknown-linux-gnueabihf.tar.gz
+# https://github.com/bootandy/dust/releases/download/v0.7.5/dust-v0.7.5-x86_64-unknown-linux-musl.tar.gz
+# https://github.com/bootandy/dust/releases/download/v0.7.5/dust-v0.7.5-x86_64-apple-darwin.tar.gz
 readonly github_coordinates=bootandy/dust
 readonly toolname=dust
 readonly filename_template=__BINARY_NAME__-v__VERSION__-__PLATFORM__.tar.gz
@@ -84,7 +85,11 @@ get_platform() {
   local operating_system
   operating_system=$(uname | tr '[:upper:]' '[:lower:]')
   if [[ "$operating_system" == "linux" ]]; then
-    echo "x86_64-unknown-linux-musl"
+    if [[ "$(uname -m)" == "aarch64" ]] || [[ "$(uname -m)" == "armv7l" ]]; then
+      echo "arm-unknown-linux-gnueabihf"
+    else
+      echo "x86_64-unknown-linux-musl"
+    fi
   else
     echo "x86_64-apple-darwin"
   fi


### PR DESCRIPTION
When installing dust from asdf, I get an binary exec error. This is because the plugin is only configured to install the x86 version on Linux. This PR will add a check for aarch64/arm7l.

```
$HOME/.asdf/installs/dust/0.7.5/bin/dust: cannot execute binary file: Exec format error
```
